### PR TITLE
Added `flush` function to IMapStorage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: java
 
 jdk:
-  - oraclejdk8
+  - openjdk8
 

--- a/src/main/java/org/bigbio/pgatk/io/mapcache/IMapStorage.java
+++ b/src/main/java/org/bigbio/pgatk/io/mapcache/IMapStorage.java
@@ -34,7 +34,7 @@ public interface IMapStorage<V> extends Serializable {
     /**
      * Retrieve a stored property for a defined item. Retruns NULL in case
      * the property has not been set.
-     * @param key
+     * @param key String key
      * @throws IndexOutOfBoundsException In case no item with this id exists.
      */
     V get(String key) throws PgatkIOException;
@@ -43,5 +43,15 @@ public interface IMapStorage<V> extends Serializable {
      * Delete all the information from the Storage
      */
     void cleanStorage() throws PgatkIOException;
+
+    /**
+     * Write all changes to disk. This function should be called
+     * after, for example, a bulk addition is done.
+     *
+     * Call this function to ensure that consumers will see newly added objects.
+     *
+     * @throws PgatkIOException In case of any i/o errors.
+     */
+    void flush() throws PgatkIOException;
 
 }

--- a/src/main/java/org/bigbio/pgatk/io/properties/InMemoryPropertyStorage.java
+++ b/src/main/java/org/bigbio/pgatk/io/properties/InMemoryPropertyStorage.java
@@ -110,8 +110,12 @@ public class InMemoryPropertyStorage implements IPropertyStorage{
         propertyStorage = null;
     }
 
+    @Override
+    public void flush() throws PgatkIOException {
+        // this method has no effect on the in-memory storage
+    }
 
-//    @Override
+    //    @Override
 //    public void toBinaryStorage(String filePath) throws PgatkIOException {
 //        if(!filePath.endsWith(PROPERTY_BINARY_EXT))
 //            throw new PgatkIOException("The provided extension for the property in memory file" +


### PR DESCRIPTION
This function is required for certain implementations that depend on
a flush method such as SparkKey.

In SparkKey flush is not triggered automatically by the put method. Flushing after every write would greatly decrease performance.